### PR TITLE
Avoid NullReferenceException on UseCatify

### DIFF
--- a/src/Owin.Catify/CatifyExtension.cs
+++ b/src/Owin.Catify/CatifyExtension.cs
@@ -10,10 +10,9 @@ namespace Owin.Catify
     {
         public static IAppBuilder UseCatify(this IAppBuilder appBuilder, string apikey = null)
         {
-            apikey = apikey.Trim();
             return string.IsNullOrWhiteSpace(apikey)
                 ?  appBuilder.Use<CatifyMiddleware>()
-                :  appBuilder.Use<CatifyMiddleware>(apikey);
+                :  appBuilder.Use<CatifyMiddleware>(apikey.Trim());
         }
     }
     


### PR DESCRIPTION
A NullReferenceException is thrown with the apiKey default value
